### PR TITLE
Fix bad method name

### DIFF
--- a/lib/faktory/rails.rb
+++ b/lib/faktory/rails.rb
@@ -9,7 +9,7 @@ module Faktory
       #
       # None of this matters on the client-side, only within the Faktory executor itself.
       #
-      Faktory.configure_exec do |_|
+      Faktory.configure_client do |_|
         Faktory.options[:reloader] = Faktory::Rails::Reloader.new
       end
     end

--- a/lib/faktory/rails.rb
+++ b/lib/faktory/rails.rb
@@ -1,18 +1,6 @@
 # frozen_string_literal: true
 module Faktory
   class Rails < ::Rails::Engine
-    config.after_initialize do
-      # This hook happens after all initializers are run, just before returning
-      # from config/environment.rb back to faktory/cli.rb.
-      # We have to add the reloader after initialize to see if cache_classes has
-      # been turned on.
-      #
-      # None of this matters on the client-side, only within the Faktory executor itself.
-      #
-      Faktory.configure_client do |_|
-        Faktory.options[:reloader] = Faktory::Rails::Reloader.new
-      end
-    end
 
     class Reloader
       def initialize(app = ::Rails.application)
@@ -27,6 +15,19 @@ module Faktory
 
       def inspect
         "#<Faktory::Rails::Reloader @app=#{@app.class.name}>"
+      end
+    end
+
+    config.after_initialize do
+      # This hook happens after all initializers are run, just before returning
+      # from config/environment.rb back to faktory/cli.rb.
+      # We have to add the reloader after initialize to see if cache_classes has
+      # been turned on.
+      #
+      # None of this matters on the client-side, only within the Faktory executor itself.
+      #
+      Faktory.configure_client do |_|
+        Faktory.options[:reloader] = Faktory::Rails::Reloader.new
       end
     end
   end if defined?(::Rails)


### PR DESCRIPTION
## Problem
Gem fails to load in Rails with:

```
undefined method `configure_exec' for Faktory:Module                                                                   
Did you mean?  configure_client
```

## Solution
I'm not 100% sure but based on my reading of `Faktory#configure_client` it makes sense that this was the intent.