### PR TITLE
add faktory_worker_ruby.rb to automatically require faktory

### DIFF
--- a/lib/faktory_worker_ruby.rb
+++ b/lib/faktory_worker_ruby.rb
@@ -1,0 +1,1 @@
+require 'faktory'


### PR DESCRIPTION
Since gem's name is `faktory_worker_ruby`, Bundle is unable to autoload the gem files. Thus, the developer should require it as:

```
gem 'faktory_worker_ruby', require: 'faktory'
```

In order to make life's developer easier, I just created a file named the same as the gem to require the faktory.rb file.