### PR TITLE
Allow setting Client URI directly.

### DIFF
--- a/lib/faktory/client.rb
+++ b/lib/faktory/client.rb
@@ -35,9 +35,9 @@ module Faktory
     # MY_FAKTORY_URL=tcp://:somepass@my-server.example.com:7419
     #
     # Note above, the URL can contain the password for secure installations.
-    def initialize(url: 'tcp://localhost:7419', debug: false)
+    def initialize(url: uri_from_env || 'tcp://localhost:7419', debug: false)
       @debug = debug
-      @location = uri_from_env || URI(url)
+      @location = URI(url)
       open
     end
 

--- a/test/faktory/client_test.rb
+++ b/test/faktory/client_test.rb
@@ -1,0 +1,24 @@
+require 'helper'
+
+class ClientFaktory < Minitest::Test
+  def test_client_initialized_with_default_url
+    client = Faktory::Client.new
+    assert_equal URI("tcp://localhost:7419"), client.instance_variable_get(:@location)
+  end
+
+  def test_client_initialized_with_env
+    ENV["FAKTORY_PROVIDER"] = "FAKTORY_URL"
+    ENV["FAKTORY_URL"] = "tcp://127.0.0.1:7419"
+
+    client = Faktory::Client.new
+    assert_equal URI("tcp://127.0.0.1:7419"), client.instance_variable_get(:@location)
+  end
+
+  def test_client_initialized_with_specific_url
+    ENV["FAKTORY_PROVIDER"] = "FAKTORY_URL"
+    ENV["FAKTORY_URL"] = "tcp://127.0.0.1:7419"
+
+    client = Faktory::Client.new(url: 'tcp://lvh.me:7419')
+    assert_equal URI("tcp://lvh.me:7419"), client.instance_variable_get(:@location)
+  end
+end

--- a/test/faktory/client_test.rb
+++ b/test/faktory/client_test.rb
@@ -18,7 +18,7 @@ class ClientFaktory < Minitest::Test
     ENV["FAKTORY_PROVIDER"] = "FAKTORY_URL"
     ENV["FAKTORY_URL"] = "tcp://127.0.0.1:7419"
 
-    client = Faktory::Client.new(url: 'tcp://lvh.me:7419')
-    assert_equal URI("tcp://lvh.me:7419"), client.instance_variable_get(:@location)
+    client = Faktory::Client.new(url: 'tcp://localhost:7419')
+    assert_equal URI("tcp://localhost:7419"), client.instance_variable_get(:@location)
   end
 end


### PR DESCRIPTION
As discussed in #5, if the ENV is set, you cannot initialize a new client by passing in the URI. This keeps the default behaviour but allows you to pass in a URI to `Faktory::Client.new`.

Fixes #5 