### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/faktory_worker_ruby.gemspec
+++ b/faktory_worker_ruby.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["mike@contribsys.com"]
   gem.summary       = "Ruby worker for Faktory"
   gem.description   = "Ruby worker for Faktory."
-  gem.homepage      = "http://github.com/contribsys/faktory_worker_ruby"
+  gem.homepage      = "https://github.com/contribsys/faktory_worker_ruby"
   gem.license       = "LGPL-3.0"
 
   gem.executables   = ['faktory-worker']


### PR DESCRIPTION
This reduces unneeded redirection when visits this gem's homepage via
https://rubygems.org/gems/faktory_worker_ruby.