### PR TITLE
Fallback to the main Faktory reloader if the manager doesn't supply one

### DIFF
--- a/lib/faktory/launcher.rb
+++ b/lib/faktory/launcher.rb
@@ -9,9 +9,10 @@ module Faktory
     attr_accessor :manager
 
     def initialize(options)
-      @manager = Faktory::Manager.new(options)
+      merged_options = Faktory.options.merge(options)
+      @manager = Faktory::Manager.new(merged_options)
       @done = false
-      @options = options
+      @options = merged_options
     end
 
     def run

--- a/lib/faktory/processor.rb
+++ b/lib/faktory/processor.rb
@@ -39,7 +39,7 @@ module Faktory
       @down = false
       @done = false
       @thread = nil
-      @reloader = mgr.options[:reloader] || Faktory.options[:reloader]
+      @reloader = mgr.options[:reloader]
       @logging = (mgr.options[:job_logger] || Faktory::JobLogger).new
       @fetcher = Faktory::Fetcher.new(mgr.options)
     end

--- a/lib/faktory/processor.rb
+++ b/lib/faktory/processor.rb
@@ -39,7 +39,7 @@ module Faktory
       @down = false
       @done = false
       @thread = nil
-      @reloader = mgr.options[:reloader]
+      @reloader = mgr.options[:reloader] || Faktory.options[:reloader]
       @logging = (mgr.options[:job_logger] || Faktory::JobLogger).new
       @fetcher = Faktory::Fetcher.new(mgr.options)
     end


### PR DESCRIPTION
I'm using the `Launcher` to start a worker, and in the log for the worker I'm seeing this error:

```
NoMethodError: undefined method `call' for nil:NilClass
faktory_worker_ruby/lib/faktory/processor.rb:132:in `block (2 levels) in dispatch'
```

This change allows fallback to the main Faktory reloader if the manager doesn't supply one. (And this fixes the problem I'm having.)

The code I'm using to start a worker is:

```
require "faktory/launcher"
faktory = Faktory::Launcher.new(queues: ["blarf"],
                                 environment: "test",
                                 concurrency: 1,
                                 timeout: 1)
faktory.run
```

Maybe instead of falling back like this, the proper solution is to pass some kind of reloader argument to the `Lanucher`? I'm not sure...