### PR TITLE
Use i18n with_locale instead of locale setter

### DIFF
--- a/lib/faktory/middleware/i18n.rb
+++ b/lib/faktory/middleware/i18n.rb
@@ -19,10 +19,8 @@ module Faktory::Middleware::I18n
   # Pull the msg locale out and set the current thread to use it.
   class Worker
     def call(jobinst, payload)
-      I18n.locale = payload.dig("custom", "locale") || I18n.default_locale
-      yield
-    ensure
-      I18n.locale = I18n.default_locale
+      locale = payload.dig("custom", "locale") || I18n.default_locale
+      I18n.with_locale(locale) { yield }
     end
   end
 end


### PR DESCRIPTION
The behaviour between i18n and faktory ruby worker is not the same.
Faktory ruby worker reset the locale to the default when i18n reset
the locale with the current locale.

To avoid any mistake I propose to use with_locale method. This method
wrap the locale reset. This avoid logic duplication and keep the logic
of locale reset in the i18n library.