### PR TITLE
Require 'digest' to satisfy production requirements

### DIFF
--- a/lib/faktory/client.rb
+++ b/lib/faktory/client.rb
@@ -1,6 +1,7 @@
 require 'socket'
 require 'json'
 require 'uri'
+require 'digest'
 require 'securerandom'
 
 module Faktory


### PR DESCRIPTION
Password hashing requires `Digest` module which is not automatically available.

Closes #24