### PR TITLE
Only load this when it's rails 5 and above

### DIFF
--- a/lib/faktory/rails.rb
+++ b/lib/faktory/rails.rb
@@ -20,7 +20,9 @@ module Faktory
       # None of this matters on the client-side, only within the Faktory executor itself.
       #
       Faktory.configure_worker do |_|
-        Faktory.options[:reloader] = Faktory::Rails::Reloader.new
+        if ::Rails::VERSION::MAJOR >= 5
+          Faktory.options[:reloader] = Faktory::Rails::Reloader.new
+        end
       end
     end
 

--- a/lib/faktory/rails.rb
+++ b/lib/faktory/rails.rb
@@ -20,9 +20,11 @@ module Faktory
       # None of this matters on the client-side, only within the Faktory executor itself.
       #
       Faktory.configure_worker do |_|
-        if ::Rails::VERSION::MAJOR >= 5
-          Faktory.options[:reloader] = Faktory::Rails::Reloader.new
+        if ::Rails::VERSION::MAJOR < 5
+          raise "Your current version of Rails, #{::Rails::VERSION::STRING}, is not supported"
         end
+        
+        Faktory.options[:reloader] = Faktory::Rails::Reloader.new
       end
     end
 
@@ -42,4 +44,11 @@ module Faktory
       end
     end
   end if defined?(::Rails)
+
+  if defined?(::Rails) && ::Rails::VERSION::MAJOR < 5
+    $stderr.puts("**************************************************")
+    $stderr.puts("🚫 ERROR: Faktory Worker does not support Rails versions under 5.x - please ensure your workers are updated")
+    $stderr.puts("**************************************************")
+    $stderr.puts("")
+  end
 end


### PR DESCRIPTION
I pulled Faktory into a project that was using Rails `4.2.10` and it started failing with this message

```
2018-10-23T19:25:05.898Z 15469 TID-ouik8horw WARN: NoMethodError: undefined method `reloader' for #<App::Application:0x00007f81e2c2d510>
Did you mean?  reloaders
2018-10-23T19:25:05.898Z 15469 TID-ouik8horw WARN: /Users/nathan/.rvm/gems/ruby-2.3.7/gems/faktory_worker_ruby-0.7.1/lib/faktory/rails.rb:33:in `call'
/Users/nathan/.rvm/gems/ruby-2.3.7/gems/faktory_worker_ruby-0.7.1/lib/faktory/processor.rb:132:in `block (2 levels) in dispatch'
/Users/nathan/.rvm/gems/ruby-2.3.7/gems/faktory_worker_ruby-0.7.1/lib/faktory/job_logger.rb:7:in `call'
/Users/nathan/.rvm/gems/ruby-2.3.7/gems/faktory_worker_ruby-0.7.1/lib/faktory/processor.rb:127:in `block in dispatch'
/Users/nathan/.rvm/gems/ruby-2.3.7/gems/faktory_worker_ruby-0.7.1/lib/faktory/logging.rb:43:in `with_context'
/Users/nathan/.rvm/gems/ruby-2.3.7/gems/faktory_worker_ruby-0.7.1/lib/faktory/logging.rb:37:in `with_job_hash_context'
/Users/nathan/.rvm/gems/ruby-2.3.7/gems/faktory_worker_ruby-0.7.1/lib/faktory/processor.rb:126:in `dispatch'
/Users/nathan/.rvm/gems/ruby-2.3.7/gems/faktory_worker_ruby-0.7.1/lib/faktory/processor.rb:145:in `process'
/Users/nathan/.rvm/gems/ruby-2.3.7/gems/faktory_worker_ruby-0.7.1/lib/faktory/processor.rb:91:in `process_one'
/Users/nathan/.rvm/gems/ruby-2.3.7/gems/faktory_worker_ruby-0.7.1/lib/faktory/processor.rb:74:in `run'
/Users/nathan/.rvm/gems/ruby-2.3.7/gems/faktory_worker_ruby-0.7.1/lib/faktory/util.rb:16:in `watchdog'
/Users/nathan/.rvm/gems/ruby-2.3.7/gems/faktory_worker_ruby-0.7.1/lib/faktory/util.rb:25:in `block in safe_thread'
```

When researching both Rails APIs I noticed that Rails 4 has `reloaders` but not `reloader` (singular.) I also noticed that [Sidekiq was only setting up the reloader on Rails 5](https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/rails.rb#L29), so I added this to match.

Let me know what you think.