### PR TITLE
Adding a cli argument for passing labels to Faktory Web UI

### DIFF
--- a/lib/faktory/cli.rb
+++ b/lib/faktory/cli.rb
@@ -235,6 +235,10 @@ module Faktory
           opts[:tag] = arg
         end
 
+        o.on '-l', '--label LABEL', "Process label to use in Faktory UI" do |arg|
+          (opts[:labels] ||= []) << arg
+        end
+
         o.on "-q", "--queue QUEUE[,WEIGHT]", "Queues to process with optional weights" do |arg|
           queue, weight = arg.split(",")
           parse_queue opts, queue, weight

--- a/lib/faktory/client.rb
+++ b/lib/faktory/client.rb
@@ -149,7 +149,7 @@ module Faktory
         "wid": @@random_process_wid,
         "hostname": Socket.gethostname,
         "pid": $$,
-        "labels": ["ruby-#{RUBY_VERSION}"],
+        "labels": Faktory.options[:labels] || ["ruby-#{RUBY_VERSION}"],
         "v": 2,
       }
 


### PR DESCRIPTION
Usage: `bundle exec faktory-worker -l 'label 1' -l 'label 2'`