### PR TITLE
Make connection pool respect custom urls

### DIFF
--- a/lib/faktory/connection.rb
+++ b/lib/faktory/connection.rb
@@ -7,7 +7,7 @@ module Faktory
       def create(options={})
         size = Faktory.worker? ? (Faktory.options[:concurrency] + 2) : 5
         ConnectionPool.new(:timeout => options[:pool_timeout] || 1, :size => size) do
-          Faktory::Client.new
+          Faktory::Client.new(options[:url] ? { url: options[:url] } : {})
         end
       end
     end

--- a/test/faktory/connection_test.rb
+++ b/test/faktory/connection_test.rb
@@ -1,0 +1,36 @@
+require 'helper'
+
+class ConnectionFaktory < Minitest::Test
+  def teardown
+    # Ensure that these tests aren't dependent on run order
+    ENV["FAKTORY_PROVIDER"] = nil
+    ENV["FAKTORY_URL"] = nil
+  end
+
+  def test_connection_initialized_with_default_url
+    pool = Faktory::Connection.create
+    pool.with do |client|
+      assert_equal URI("tcp://localhost:7419"), client.instance_variable_get(:@location)
+    end
+  end
+
+  def test_connection_initialized_with_env
+    ENV["FAKTORY_PROVIDER"] = "FAKTORY_URL"
+    ENV["FAKTORY_URL"] = "tcp://127.0.0.1:7419"
+
+    pool = Faktory::Connection.create
+    pool.with do |client|
+      assert_equal URI("tcp://127.0.0.1:7419"), client.instance_variable_get(:@location)
+    end
+  end
+
+  def test_connection_initialized_with_specific_url
+    ENV["FAKTORY_PROVIDER"] = "FAKTORY_URL"
+    ENV["FAKTORY_URL"] = "tcp://127.0.0.1:7419"
+
+    pool = Faktory::Connection.create(url: 'tcp://localhost:7419')
+    pool.with do |client|
+      assert_equal URI("tcp://localhost:7419"), client.instance_variable_get(:@location)
+    end
+  end
+end


### PR DESCRIPTION
I found that the clients created within the connection pool would not respect custom urls. This PR fixes that.