### PR TITLE
Squish `JSON.dump` results before sending command

### DIFF
--- a/lib/faktory/client.rb
+++ b/lib/faktory/client.rb
@@ -86,7 +86,7 @@ module Faktory
         command("FAIL", JSON.dump({ message: ex.message[0...1000],
                           errtype: ex.class.name,
                           jid: jid,
-                          backtrace: ex.backtrace}))
+                          backtrace: ex.backtrace}).squish)
         ok!
       end
     end
@@ -186,7 +186,7 @@ module Faktory
         end
       end
 
-      command("HELLO", JSON.dump(payload))
+      command("HELLO", JSON.dump(payload).squish)
       ok!
     end
 


### PR DESCRIPTION
When a client connects to Faktory server, the server seems to [expect a single line of JSON](https://github.com/contribsys/faktory/blob/5ce7d066fa8dda4abc5259090c76885ba84e0341/server/server.go#L208). If the client sends multiple lines (e.g., because the JSON is prettified), Faktory server says `unexpected end of JSON input Invalid client data in HELLO` and the client sees `Errno::ECONNRESET: Connection reset by peer - No response`.

Squishing the result of `JSON.dump` before sending the command to the server seems to fix the issue.

(Now why would anybody send pretty JSON to the Faktory server? -- Well, in our case it was an unintended consequence of having the [oj](https://github.com/ohler55/oj) gem with `Oj.default_options = { indent: 4 }` and `Oj.optimize_rails` in the Faktory worker; these `oj` settings cause `JSON.dump` to output pretty JSON).