### PR TITLE
Preserve timeout after reconnect in transaction

### DIFF
--- a/test/faktory/client_test.rb
+++ b/test/faktory/client_test.rb
@@ -12,6 +12,16 @@ class ClientFaktory < Minitest::Test
     assert_equal URI("tcp://localhost:7419"), client.instance_variable_get(:@location)
   end
 
+  def test_client_initialized_with_default_timeout
+    client = Faktory::Client.new
+    assert_equal Faktory::Client::DEFAULT_TIMEOUT, client.instance_variable_get(:@timeout)
+  end
+
+  def test_client_initialized_with_specific_timeout
+    client = Faktory::Client.new(timeout: 0.1)
+    assert_equal 0.1, client.instance_variable_get(:@timeout)
+  end
+
   def test_client_initialized_with_env
     ENV["FAKTORY_PROVIDER"] = "FAKTORY_URL"
     ENV["FAKTORY_URL"] = "tcp://127.0.0.1:7419"


### PR DESCRIPTION
Fixes socket timeout being reset to default after reconnect in transaction. 

