### PR TITLE
Make creating polyglot jobs easier

### DIFF
--- a/test/polyglot_test.rb
+++ b/test/polyglot_test.rb
@@ -1,0 +1,51 @@
+require 'helper'
+
+class PolyglotTest < LiveTest
+  describe 'jobs with non ruby class jobtype' do
+    before do
+      require 'faktory/testing'
+      Faktory::Testing.fake!
+    end
+
+    after do
+      Faktory::Testing.disable!
+      Faktory::Queues.clear_all
+    end
+
+    it 'perform_async' do
+      Faktory::Job.perform_async('someFunc')
+      assert_equal 1, Faktory::Queues['default'].size
+
+      job = Faktory::Queues['default'].last
+      assert_equal 'someFunc', job['jobtype']
+      assert_equal [], job['args']
+
+      Faktory::Job.perform_async('someFunc', ['some', 'args'], queue: 'some_q')
+      assert_equal 1, Faktory::Queues['some_q'].size
+
+      job = Faktory::Queues['some_q'].last
+      assert_equal 'someFunc', job['jobtype']
+      assert_equal ['some', 'args'], job['args']
+    end
+
+    it 'perform_in' do
+      Faktory::Job.perform_in(10, 'someFunc')
+      assert_equal 1, Faktory::Queues['default'].size
+
+      job = Faktory::Queues['default'].last
+      assert_equal 'someFunc', job['jobtype']
+      assert_equal [], job['args']
+      assert_in_delta Time.now.to_f, Time.parse(job['at']).to_f, 10.1
+
+
+      Faktory::Job.perform_in(10, 'someFunc', ['some', 'args'], queue: 'some_q')
+      assert_equal 1, Faktory::Queues['some_q'].size
+
+      job = Faktory::Queues['some_q'].first
+      assert_equal 'someFunc', job['jobtype']
+      assert_equal 'some_q', job['queue']
+      assert_equal ['some', 'args'], job['args']
+      assert_in_delta Time.now.to_f, Time.parse(job['at']).to_f, 10.1
+    end
+  end
+end

--- a/test/polyglot_test.rb
+++ b/test/polyglot_test.rb
@@ -13,14 +13,7 @@ class PolyglotTest < LiveTest
     end
 
     it 'perform_async' do
-      Faktory::Job.perform_async('someFunc')
-      assert_equal 1, Faktory::Queues['default'].size
-
-      job = Faktory::Queues['default'].last
-      assert_equal 'someFunc', job['jobtype']
-      assert_equal [], job['args']
-
-      Faktory::Job.perform_async('someFunc', ['some', 'args'], queue: 'some_q')
+      Faktory::Job.set(queue: 'some_q', jobtype: 'someFunc').perform_async('some', 'args')
       assert_equal 1, Faktory::Queues['some_q'].size
 
       job = Faktory::Queues['some_q'].last
@@ -29,16 +22,7 @@ class PolyglotTest < LiveTest
     end
 
     it 'perform_in' do
-      Faktory::Job.perform_in(10, 'someFunc')
-      assert_equal 1, Faktory::Queues['default'].size
-
-      job = Faktory::Queues['default'].last
-      assert_equal 'someFunc', job['jobtype']
-      assert_equal [], job['args']
-      assert_in_delta Time.now.to_f, Time.parse(job['at']).to_f, 10.1
-
-
-      Faktory::Job.perform_in(10, 'someFunc', ['some', 'args'], queue: 'some_q')
+      Faktory::Job.set(queue: 'some_q', jobtype: 'someFunc').perform_in(10, 'some', 'args')
       assert_equal 1, Faktory::Queues['some_q'].size
 
       job = Faktory::Queues['some_q'].first

--- a/test/polyglot_test.rb
+++ b/test/polyglot_test.rb
@@ -12,6 +12,8 @@ class PolyglotTest < LiveTest
       Faktory::Queues.clear_all
     end
 
+    SomePolyglotJob = Faktory::Job.set(queue: 'some_q', jobtype: 'someFunc')
+
     it 'perform_async' do
       Faktory::Job.set(queue: 'some_q', jobtype: 'someFunc').perform_async('some', 'args')
       assert_equal 1, Faktory::Queues['some_q'].size
@@ -30,6 +32,19 @@ class PolyglotTest < LiveTest
       assert_equal 'some_q', job['queue']
       assert_equal ['some', 'args'], job['args']
       assert_in_delta Time.now.to_f, Time.parse(job['at']).to_f, 10.1
+    end
+
+    it 'perform_async via constant' do
+      SomePolyglotJob.perform_async('some', 'args')
+      SomePolyglotJob.perform_async('some', 'args')
+
+      assert_equal 2, Faktory::Queues['some_q'].size
+
+      job = Faktory::Queues['some_q'].last
+      assert_equal 'someFunc', job['jobtype']
+      assert_equal ['some', 'args'], job['args']
+
+      assert Faktory::Queues['some_q'].first["jid"] != Faktory::Queues['some_q'].last["jid"]
     end
   end
 end

--- a/test/testing_fake_test.rb
+++ b/test/testing_fake_test.rb
@@ -331,7 +331,7 @@ class TestingFakeTest < LiveTest
     end
 
     it 'perform_async' do
-      Faktory::Job.perform_async('someFunc', ['some', 'args'], queue: 'some_q')
+      Faktory::Job.set(queue: 'some_q', jobtype: 'someFunc').perform_async('some', 'args')
       assert_equal 1, Faktory::Queues['some_q'].size
 
       job = Faktory::Queues['some_q'].first
@@ -341,7 +341,7 @@ class TestingFakeTest < LiveTest
     end
 
     it 'perform_in' do
-      Faktory::Job.perform_in(10, 'someFunc', ['some', 'args'], queue: 'some_q')
+      Faktory::Job.set(queue: 'some_q', jobtype: 'someFunc').perform_in(10, 'some', 'args')
       assert_equal 1, Faktory::Queues['some_q'].size
 
       job = Faktory::Queues['some_q'].first

--- a/test/testing_fake_test.rb
+++ b/test/testing_fake_test.rb
@@ -318,4 +318,37 @@ class TestingFakeTest < LiveTest
       assert_equal 1, jobs.size
     end
   end
+
+  describe 'polyglot testing' do
+    before do
+      require 'faktory/testing'
+      Faktory::Testing.fake!
+    end
+
+    after do
+      Faktory::Testing.disable!
+      Faktory::Queues.clear_all
+    end
+
+    it 'perform_async' do
+      Faktory::Job.perform_async('someFunc', ['some', 'args'], queue: 'some_q')
+      assert_equal 1, Faktory::Queues['some_q'].size
+
+      job = Faktory::Queues['some_q'].first
+      assert_equal 'someFunc', job['jobtype']
+      assert_equal 'some_q', job['queue']
+      assert_equal ['some', 'args'], job['args']
+    end
+
+    it 'perform_in' do
+      Faktory::Job.perform_in(10, 'someFunc', ['some', 'args'], queue: 'some_q')
+      assert_equal 1, Faktory::Queues['some_q'].size
+
+      job = Faktory::Queues['some_q'].first
+      assert_equal 'someFunc', job['jobtype']
+      assert_equal 'some_q', job['queue']
+      assert_equal ['some', 'args'], job['args']
+      assert_in_delta Time.now.to_f, Time.parse(job['at']).to_f, 10.1
+    end
+  end
 end

--- a/test/testing_inline_test.rb
+++ b/test/testing_inline_test.rb
@@ -31,8 +31,14 @@ class TestingInlineTest < LiveTest
       Faktory::Testing.inline! do
         assert InlineJob.perform_async(true)
 
+        assert Faktory::Job.perform_async(InlineJob, [true])
+
         assert_raises InlineError do
           InlineJob.perform_async(false)
+        end
+
+        assert_raises InlineError do
+          Faktory::Job.perform_async(InlineJob, [false])
         end
       end
     end
@@ -54,6 +60,14 @@ class TestingInlineTest < LiveTest
             "jobtype" => InlineJob,
             "args" => [false]
           })
+        end
+      end
+    end
+
+    it 'raises error for non-existing jobtype class' do
+      Faktory::Testing.inline! do
+        assert_raises NameError do
+          Faktory::Job.perform_async('someFunc')
         end
       end
     end

--- a/test/testing_inline_test.rb
+++ b/test/testing_inline_test.rb
@@ -31,14 +31,14 @@ class TestingInlineTest < LiveTest
       Faktory::Testing.inline! do
         assert InlineJob.perform_async(true)
 
-        assert Faktory::Job.perform_async(InlineJob, [true])
+        assert Faktory::Job.set(jobtype: InlineJob).perform_async(true)
 
         assert_raises InlineError do
           InlineJob.perform_async(false)
         end
 
         assert_raises InlineError do
-          Faktory::Job.perform_async(InlineJob, [false])
+          Faktory::Job.set(jobtype: InlineJob).perform_async(false)
         end
       end
     end
@@ -67,7 +67,7 @@ class TestingInlineTest < LiveTest
     it 'raises error for non-existing jobtype class' do
       Faktory::Testing.inline! do
         assert_raises NameError do
-          Faktory::Job.perform_async('someFunc')
+          Faktory::Job.set(jobtype: 'someFunc').perform_async
         end
       end
     end


### PR DESCRIPTION
Allows for easier enqueuing of jobs where the Job processor lives in another system.

```ruby
Faktory::Job.set(jobtype: 'someFunc', queue: 'some_queue').perform_async("arg1", 2)
Faktory::Job.set(jobtype: 'someFunc', queue: 'some_queue').perform_in(12.minute, "arg1", 2)

MyPolyglotJob = Faktory::Job.set(queue: 'some_q', jobtype: 'someFunc')
MyPolyglotJob.perform_async("arg1", 2)
```

The enqueuing ruby process does not need to know the Job class. So we can use any jobtype name, as long as the worker process knows how to deal with it.
Traditional Job class (mixing in Faktory::Job + `SomeJob.perform_async`) still enforce their own class name as jobtype.

Also see discussion in #30 
