### PR TITLE
Notify the Faktory Server when a process is going quiet and also when terminating

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@
 - Refactor Faktory::Client error handling for faktory#208
 - Support for the MUTATE command.
 - Support for Faktory Enterprise and job batches
+- Notify Faktory when a worker process is going quiet so that the UI shows this
 
 ## 0.8.1
 

--- a/lib/faktory/client.rb
+++ b/lib/faktory/client.rb
@@ -161,17 +161,17 @@ module Faktory
     # worker process is still alive.
     #
     # You can pass in the current_state of the process, for example during shutdown
-    # quiet and/or terminate can be supplied. 
+    # quiet and/or terminate can be supplied.
     #
     # Return a string signal to process, legal values are "quiet" or "terminate".
     # The quiet signal is informative: the server won't allow this process to FETCH
     # any more jobs anyways.
     def beat(current_state = nil)
       transaction do
-        if current_state.present?
-          command("BEAT", %Q[{"wid":"#{@@random_process_wid}", "current_state":"#{current_state}"}])
-        else
+        if current_state.nil?
           command("BEAT", %Q[{"wid":"#{@@random_process_wid}"}])
+        else
+          command("BEAT", %Q[{"wid":"#{@@random_process_wid}", "current_state":"#{current_state}"}])
         end
 
         str = result!
@@ -359,4 +359,3 @@ module Faktory
 
   end
 end
-

--- a/lib/faktory/client.rb
+++ b/lib/faktory/client.rb
@@ -160,12 +160,15 @@ module Faktory
     # Sends a heartbeat to the server, in order to prove this
     # worker process is still alive.
     #
+    # You can pass in the current_state of the process, for example during shutdown
+    # quiet and/or terminate can be supplied. 
+    #
     # Return a string signal to process, legal values are "quiet" or "terminate".
     # The quiet signal is informative: the server won't allow this process to FETCH
     # any more jobs anyways.
-    def beat
+    def beat(current_state = nil)
       transaction do
-        command("BEAT", %Q[{"wid":"#{@@random_process_wid}"}])
+        command("BEAT", %Q[{"wid":"#{@@random_process_wid}", "current_state":"#{current_state}"}])
         str = result!
         if str == "OK"
           str

--- a/lib/faktory/client.rb
+++ b/lib/faktory/client.rb
@@ -168,7 +168,12 @@ module Faktory
     # any more jobs anyways.
     def beat(current_state = nil)
       transaction do
-        command("BEAT", %Q[{"wid":"#{@@random_process_wid}", "current_state":"#{current_state}"}])
+        if current_state.present?
+          command("BEAT", %Q[{"wid":"#{@@random_process_wid}", "current_state":"#{current_state}"}])
+        else
+          command("BEAT", %Q[{"wid":"#{@@random_process_wid}"}])
+        end
+
         str = result!
         if str == "OK"
           str

--- a/lib/faktory/manager.rb
+++ b/lib/faktory/manager.rb
@@ -62,7 +62,6 @@ module Faktory
 
     def stop(deadline)
       quiet
-
       fire_event(:shutdown, true)
 
       # some of the shutdown events can be async,

--- a/lib/faktory/manager.rb
+++ b/lib/faktory/manager.rb
@@ -49,6 +49,9 @@ module Faktory
     end
 
     def quiet
+      # Notify the server that this process is going quiet
+      Faktory.server {|c| c.beat(:quiet) }
+
       return if @done
       @done = true
 
@@ -62,6 +65,9 @@ module Faktory
 
     def stop(deadline)
       quiet
+
+      # Notify the server that this process is terminating
+      Faktory.server {|c| c.beat(:terminate) }
       fire_event(:shutdown, true)
 
       # some of the shutdown events can be async,

--- a/lib/faktory/manager.rb
+++ b/lib/faktory/manager.rb
@@ -49,9 +49,6 @@ module Faktory
     end
 
     def quiet
-      # Notify the server that this process is going quiet
-      Faktory.server {|c| c.beat(:quiet) }
-
       return if @done
       @done = true
 
@@ -66,8 +63,6 @@ module Faktory
     def stop(deadline)
       quiet
 
-      # Notify the server that this process is terminating
-      Faktory.server {|c| c.beat(:terminate) }
       fire_event(:shutdown, true)
 
       # some of the shutdown events can be async,


### PR DESCRIPTION
1 question for you @mperham around this.

Is sending `nil` as the `current_state` ok, or should I add a conditional to only send that when there is no state. Seems like a waste of bytes otherwise, but will let you answer before I add more complexity. 

<img width="757" alt="Screenshot 2020-01-11 at 17 25 30" src="https://user-images.githubusercontent.com/68361/72208153-7a9c6f80-3497-11ea-96d4-28e905bb81ad.png">

<img width="885" alt="Screenshot 2020-01-11 at 17 25 46" src="https://user-images.githubusercontent.com/68361/72208154-7cfec980-3497-11ea-9629-d9b04ffa0ee6.png">

One thing i have noticed is that it still takes a little while for the UI to remove the worker, even after sending the `current_state = terminate`. Is this by design?
