### PR TITLE
Set `bid` when creating job objects, so that `batch` can be used within the jobs

### DIFF
--- a/lib/faktory/processor.rb
+++ b/lib/faktory/processor.rb
@@ -133,6 +133,7 @@ module Faktory
             klass  = constantize(payload['jobtype'.freeze])
             jobinst = klass.new
             jobinst.jid = payload['jid'.freeze]
+            jobinst.bid = payload['custom'.freeze].to_h['bid'.freeze]
             yield jobinst
           end
         end


### PR DESCRIPTION
Fixes #44