### PR TITLE
Invoke client middlewares when enqueueing via ActiveJob

### DIFF
--- a/test/active_job/queue_adapters/faktory_adapter_test.rb
+++ b/test/active_job/queue_adapters/faktory_adapter_test.rb
@@ -1,5 +1,6 @@
 require 'helper'
 require 'active_job/queue_adapters/faktory_adapter'
+require 'faktory/middleware/i18n'
 
 # quiet a lot of AJ noise
 ActiveJob::Base.logger = Logger.new(nil)
@@ -66,5 +67,11 @@ class FaktoryAdapterTest < LiveTest
       assert_equal 6, TestJob.count
     end
 
+    it 'executes client middlewares on push' do
+      TestJob.perform_later(123)
+
+      job = ActiveJob::QueueAdapters::FaktoryAdapter::JobWrapper.jobs.last
+      assert_equal "en", job["custom"]["locale"]
+    end
   end
 end


### PR DESCRIPTION
I noticed that client middlewares are not being called if I'm using ActiveJob. This pull request fixes that.

Thank you for faktory!