### PR TITLE
Fix Ruby 2.7 warning

### DIFF
--- a/lib/faktory/connection.rb
+++ b/lib/faktory/connection.rb
@@ -7,7 +7,7 @@ module Faktory
       def create(options={})
         size = Faktory.worker? ? (Faktory.options[:concurrency] + 2) : 5
         ConnectionPool.new(:timeout => options[:pool_timeout] || 1, :size => size) do
-          Faktory::Client.new(options)
+          Faktory::Client.new(**options)
         end
       end
     end


### PR DESCRIPTION
"Using the last argument as keyword parameters is deprecated"