### PR TITLE
Fixes read_timeout for SSLSocket socket types

### DIFF
--- a/lib/faktory/io.rb
+++ b/lib/faktory/io.rb
@@ -37,9 +37,9 @@ module Faktory
       loop do
         result = @sock.read_nonblock(nbytes, exception: false)
         if result == :wait_readable
-          raise Faktory::TimeoutError unless @sock.wait_readable(@timeout)
+          raise Faktory::TimeoutError unless @sock.to_io.wait_readable(@timeout)
         elsif result == :wait_writable
-          raise Faktory::TimeoutError unless @sock.wait_writeable(@timeout)
+          raise Faktory::TimeoutError unless @sock.to_io.wait_writeable(@timeout)
         elsif result == nil
           raise Errno::ECONNRESET
         else


### PR DESCRIPTION
Fixes #59 - NoMethodError (undefined method `wait_readable' for #<OpenSSL::SSL::SSLSocket:0x00007fc7641dea60>) 

@mperham - Any idea on adding tests for TLS endpoints?