### PR TITLE
Implement using -r with a directory of job classes.

### DIFF
--- a/lib/faktory/cli.rb
+++ b/lib/faktory/cli.rb
@@ -176,6 +176,9 @@ module Faktory
     end
 
     def boot_rails_app
+        logger.debug("Found rails app in #{options[:require]}")
+        logger.debug("Worker boot: loading rails and config/environment.rb")
+
         require "rails"
         require "faktory/rails"
         require File.expand_path("#{options[:require]}/config/environment.rb")
@@ -183,13 +186,13 @@ module Faktory
     end
 
     def boot_worker(req_file)
-        require(req_file) && logger.info("Loaded #{req_file}")
+        require(req_file) && logger.debug("Standalone worker boot: loaded #{req_file}")
     end
 
     def boot_worker_multi
-        rb_files = Dir.glob("#{options[:require]}/**/*.rb").flatten
+        rb_files = Dir.glob("./#{options[:require]}/**/*.rb").flatten
         rb_files.each do |req_file|
-          boot_worker(req_file)
+          boot_worker(File.expand_path(req_file))
         end
     end
 


### PR DESCRIPTION
Currently, the `-r` flag supports being passed the root directory of a rails app or a _single_ ruby file. In my use case, I'm often writing small APIs or celluloid apps bundled with a handful of jobs (usually living in ./lib/jobs). If I want faktory-worker to require all of my jobs, I need to maintain a separate file `require`-ing all of my job classes.

Instinctively I feel like you'd think you could use `-r` with a dir glob, or with the path to a directory. So here's a first crack at a proposal which implements that behavior.

I've also taken a little bit of artistic liberty with cleaning up the logical operators in boot_system, since I had to make some changes there anyway.

--------

This is just a draft PR; I'm curious about your thoughts and would like some direction if you think this is useful.