### PR TITLE
Fix broken test caused by checking for attributes

### DIFF
--- a/test/system_test.rb
+++ b/test/system_test.rb
@@ -12,10 +12,10 @@ class SystemTest < LiveTest
 
   def randjob(idx)
     {
-      jid: "1231278127839" + idx.to_s,
-      queue: "default",
-      jobtype: "SomeJob",
-      args: [1, "string", 3]
+      "jid"     => "1231278127839" + idx.to_s,
+      "queue"   => "default",
+      "jobtype" => "SomeJob",
+      "args"    => [1, "string", 3]
     }
   end
 


### PR DESCRIPTION
Faktory lib checks for the presence of string hash keys, test passes a hash with symbols.

Most likely in production it's correct to expect string keys (given json decoding), but the test is directly calling .push.

This PR fixes the data structure we're passing. 