### PR TITLE
Rescue OpenSSL errors in Client#transaction

### DIFF
--- a/lib/faktory/client.rb
+++ b/lib/faktory/client.rb
@@ -321,7 +321,7 @@ module Faktory
 
       begin
         yield
-      rescue SystemCallError, SocketError, TimeoutError
+      rescue SystemCallError, SocketError, TimeoutError, OpenSSL::SSL::SSLError
         if retryable
           retryable = false
 


### PR DESCRIPTION
This feels like a similar category of socket/network-related errors that could be handled in a similar fashion.

This may help resolve the issues experienced in #51. Ultimately it probably indicates a network issue, but it seems like right now things get into a bad state if this exception is raised.

I don't know if e.g. jobs would get double-pushed if this handler were to handle this exception, but that is probably preferable to a process getting into a bad state until it's killed.