### PR TITLE
Add enqueue_after_transaction_commit? method for Rails 7.2 support

### DIFF
--- a/lib/active_job/queue_adapters/faktory_adapter.rb
+++ b/lib/active_job/queue_adapters/faktory_adapter.rb
@@ -40,6 +40,10 @@ module ActiveJob
         end
       end
 
+      def enqueue_after_transaction_commit?(job) # :nodoc:
+        true
+      end
+
       class JobWrapper # :nodoc:
         include Faktory::Job
 


### PR DESCRIPTION
## Problem
Rails 7.2's `EnqueueAfterTransactionCommit` calls `queue_adapter.enqueue_after_transaction_commit?` to defer `perform_later` until after ActiveRecord commits. The `FaktoryAdapter` doesn't implement this method, causing a `NoMethodError` when enqueuing jobs within transactions.

## Solution
Add the `enqueue_after_transaction_commit?(job)` method to `FaktoryAdapter` that returns `true`, indicating support for deferred job enqueuing after transaction commits.

## Changes
- Added `enqueue_after_transaction_commit?(job)` method to `FaktoryAdapter` class (returns `true`)

## Impact
- ✅ Fixes `NoMethodError` when calling `perform_later` with ActiveRecord transactions
- ✅ Ensures jobs won't be enqueued if the transaction rolls back
- ✅ Makes FaktoryAdapter compatible with Rails 7.2+

## Testing
Jobs can now be safely enqueued within database transactions without errors.